### PR TITLE
Hide tooltip frame when tooltip clears

### DIFF
--- a/IDTooltipFrame.lua
+++ b/IDTooltipFrame.lua
@@ -479,7 +479,10 @@ eventFrame:SetScript("OnEvent", function(_, event, arg1)
             end)
 
             GameTooltip:HookScript("OnTooltipCleared", function()
-                if frame and frame.isLocked then frame.text:SetText("") end
+                if frame and frame.isLocked then
+                    frame.text:SetText("")
+                    frame:Hide()
+                end
             end)
 
             -- Slash commands


### PR DESCRIPTION
### Motivation
- Prevent the ID frame from lingering on-screen empty after the cursor moves away from an item or spell so it only shows while a tooltip is active.

### Description
- Modify `IDTooltipFrame.lua` to call `frame:Hide()` in the `GameTooltip:HookScript("OnTooltipCleared", ...)` handler (in addition to clearing the text) so the frame is hidden when the tooltip clears.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979481eec908321aba1d9390eb25c5f)